### PR TITLE
Remove auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "deploy": "pylon build && wrangler deploy",
     "dev": "pylon dev -c \"wrangler dev --port 3000\" --client --client-port 3000 --client-path ./clients/jaen-agent/index.ts",
     "cf-typegen": "wrangler types",
-		"start": "wrangler dev",
-		"test": "vitest",
-		"build": "tsc",
-		"migrate:deploy": "./scripts/migrate.sh prod",
+                "start": "wrangler dev",
+                "test": "vitest",
+                "build": "tsc",
+                "postinstall": "patch-package",
+                "migrate:deploy": "./scripts/migrate.sh prod",
 		"migrate:reset": "./scripts/migrate.sh reset",
 		"migrate:seed": "./scripts/migrate.sh seed dev",
 		"migrate:status": "./scripts/migrate.sh status",
@@ -40,6 +41,7 @@
     "prisma": "^6.9.0",
     "typescript": "^5.6.3",
     "wrangler": "^3.60.3"
+    ,"patch-package": "^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@getcronit/pylon-dev": "^1.0.0",
     "prisma": "^6.9.0",
     "typescript": "^5.6.3",
-    "wrangler": "^3.60.3"
-    ,"patch-package": "^8.0.0"
+    "wrangler": "^3.60.3",
+    "patch-package": "^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/patches/@getcronit+pylon+2.0.0.patch
+++ b/patches/@getcronit+pylon+2.0.0.patch
@@ -1,0 +1,24 @@
+*** Begin Patch
+*** Update File: node_modules/@getcronit/pylon/auth.js
+@@
+-  const sign = crypto.createSign('RSA-SHA256');
+-  sign.update(payload);
+-  return sign.sign(privateKey, 'base64');
++  // Cloudflare Workers do not support crypto.createSign.
++  // Use WebCrypto to sign instead.
++  const encoder = new TextEncoder();
++  const key = await crypto.subtle.importKey(
++    'pkcs8',
++    typeof privateKey === 'string' ? Buffer.from(privateKey, 'base64') : privateKey,
++    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
++    false,
++    ['sign']
++  );
++  const signature = await crypto.subtle.sign(
++    'RSASSA-PKCS1-v1_5',
++    key,
++    encoder.encode(payload)
++  );
++  return Buffer.from(signature).toString('base64');
+ }
+*** End Patch


### PR DESCRIPTION
## Summary
- drop `auth` usage to avoid crypto.createSign
- patch pylon to avoid crypto.createSign

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'bun-types')*
- `npm test` *(fails: vitest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6860245c2490832d86639962e35b1ba3